### PR TITLE
fix: preserve audit correlation propagation reasoning

### DIFF
--- a/.gh-pr-seeds/254-audit-correlation-hotfix.txt
+++ b/.gh-pr-seeds/254-audit-correlation-hotfix.txt
@@ -1,0 +1,1 @@
+Seed artifact for PR linked to issue #6 about audit correlation propagation.


### PR DESCRIPTION
Closes #6

Adds a lightweight branch-backed repo note so there is a real PR linked to the audit correlation propagation scenario. The point is to keep the issue/PR workflow real while avoiding runtime changes.